### PR TITLE
Add support for the Ghostty terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ Running these commands in sequence from the repo root should work
 out-of-the-box after having installed the CLI tool.
 
 ## Applications
-This repo provides palette-agnostic theme templates for `kitty`,
-`vim`/`neovim`, and `fzf` in the `templates/` directory. Pre-generated
-*concrete* themes can be found in `app-config/`, if you'd like to try an
-example out-of-the-box without using the `monobiome` CLI. Raw
-palette colors can be found in `colors/` if you want to use them to define
-static themes for other applications.
+This repo provides palette-agnostic theme templates for `ghostty`,
+`kitty`, `vim`/`neovim`, and `fzf` in the `templates/` directory.
+Pre-generated *concrete* themes can be found in `app-config/`, if you'd
+like to try an example out-of-the-box without using the `monobiome` CLI.
+Raw palette colors can be found in `colors/` if you want to use them to
+define static themes for other applications.
 
 Themes files in the `app-config/` directory are generated for light and dark
 modes of each biome, and named according to the following pattern:

--- a/templates/ghostty/config
+++ b/templates/ghostty/config
@@ -1,0 +1,41 @@
+# base settings
+background = f{{term.background}}
+foreground = f{{term.foreground}}
+
+selection-background = f{{term.selection_bg}}
+selection-foreground = f{{term.selection_fg}}
+
+cursor-color = f{{term.cursor}}
+cursor-text = f{{term.cursor_text}}
+
+# black
+palette = 0=f{{term.normal.black}}
+palette = 8=f{{term.bright.black}}
+
+# red
+palette = 1=f{{term.normal.red}}
+palette = 9=f{{term.bright.red}}
+
+# green
+palette = 2=f{{term.normal.green}}
+palette = 10=f{{term.bright.green}}
+
+# yellow
+palette = 3=f{{term.normal.yellow}}
+palette = 11=f{{term.bright.yellow}}
+
+# blue
+palette = 4=f{{term.normal.blue}}
+palette = 12=f{{term.bright.blue}}
+
+# magenta (red)
+palette = 5=f{{term.normal.magenta}}
+palette = 13=f{{term.bright.magenta}}
+
+# cyan (blue)
+palette = 6=f{{term.normal.cyan}}
+palette = 14=f{{term.bright.cyan}}
+
+# white
+palette = 7=f{{term.normal.white}}
+palette = 15=f{{term.bright.white}}


### PR DESCRIPTION
Add supports for the [Ghostty](https://ghostty.org) terminal. I've used https://ghostty.org/docs/features/theme as a reference for the implementation. Loading the theme configuration is done using the `config-file` directive as described in https://ghostty.org/docs/config#splitting-into-multiple-files.